### PR TITLE
chore(Odoo): change Odoo base image tag to latest hash

### DIFF
--- a/odoo/Dockerfile
+++ b/odoo/Dockerfile
@@ -1,4 +1,4 @@
-FROM odoo@sha256:7e276b60e3518e9e3bd95f545328be5ce6c724604fea059d19ab73bea5199c84
+FROM odoo@sha256:006e79693b044bf0e7ed912da4dd082bcc1724d14f5ab4a14a679b62194b38f8
 
 COPY ./run.sh /glasskube/
 

--- a/odoo/run.sh
+++ b/odoo/run.sh
@@ -5,6 +5,9 @@ RESULT_NOK=1
 RESULT_FAIL=2
 
 DB_NAME="odoo"
+VOLUME_DIR="/var/lib/odoo"
+VERSION_FILE="$VOLUME_DIR/last_version.txt"
+CURRENT_VERSION=$(odoo --version)
 
 function abort {
   reason=$1
@@ -37,11 +40,33 @@ function update_db {
   /entrypoint.sh "$@" "--update" "all" "-d" "$DB_NAME" "--stop-after-init"
 }
 
+function invalidate_assets {
+  if [ -f "$VERSION_FILE" ]; then
+    LAST_VERSION="$(<"$VERSION_FILE")"
+    echo "Last version was $LAST_VERSION"
+  else
+    LAST_VERSION="n.a."
+    echo "Version file does not exist"
+  fi
+
+  if [ "$CURRENT_VERSION" != "$LAST_VERSION" ]; then
+    echo "Current version differs from previous version ($CURRENT_VERSION =/= $LAST_VERSION)"
+    PGHOST="$HOST" PGUSER="$USER" PGPASSWORD="$PASSWORD" PGDATABASE="$DB_NAME" \
+      psql -qc "delete from ir_attachment where res_model='ir.ui.view' and name like '%assets_%'" \
+      >/dev/null
+  fi
+}
+
+function print_version_file() {
+  printf "%s" "$CURRENT_VERSION" >"$VERSION_FILE"
+}
+
 check_db
 
 case $? in
 "$RESULT_OK")
   echo "Database already initialized"
+  invalidate_assets
   update_db "$@"
   ;;
 "$RESULT_NOK")
@@ -52,5 +77,7 @@ case $? in
   abort "Error connecting to database server"
   ;;
 esac
+
+print_version_file
 
 exec "/entrypoint.sh" "$@"


### PR DESCRIPTION
This change now includes a fix for some frontend asset errors after an update. 

The Odoo version included is: `16.0-20230317`