### PR TITLE
chore(Matomo): update base image version to 4.14.2

### DIFF
--- a/matomo/Dockerfile
+++ b/matomo/Dockerfile
@@ -1,4 +1,4 @@
-FROM matomo:4.14.1-apache
+FROM matomo:4.14.2-apache
 LABEL org.opencontainers.image.source=https://github.com/glasskube/images/tree/main/matomo
 
 RUN set -ex; \


### PR DESCRIPTION
Related changelog: https://matomo.org/changelog/matomo-4-14-2/